### PR TITLE
Scale ALIGN memory dynamically based on input FASTQ size

### DIFF
--- a/modules/local/align/main.nf
+++ b/modules/local/align/main.nf
@@ -11,7 +11,17 @@ process ALIGN {
 
       base_cpus * task.attempt
     }
-    memory { 12.GB * task.attempt }
+    memory {
+      def size1 = fastqs1 instanceof Collection ? fastqs1.sum{ it.size() } : fastqs1.size()
+      def size2 = fastqs2 instanceof Collection ? fastqs2.sum{ it.size() } : fastqs2.size()
+      def total = size1 + size2
+
+      def base_mem = total < 500.MB ? 12.GB :  // small
+                     total < 1.GB   ? 24.GB :  // medium
+                     48.GB                     // large (≥1 GB)
+
+      base_mem * task.attempt
+    }
     label 'process_high'
 
   input:


### PR DESCRIPTION
Scale ALIGN memory dynamically based on input FASTQ size
The ALIGN process already scales CPUs based on compressed FASTQ size
(<500MB→1, <1GB→4, ≥1GB→12 × attempt). Memory was previously fixed at
12GB × attempt regardless of cell coverage, causing high-coverage cells
to repeatedly OOM-kill across all retry attempts (max 36GB at attempt 3).

Apply the same size tiers to the memory closure:
- small  (<500MB):  12GB × attempt (unchanged)
- medium (<1GB):    24GB × attempt
- large  (≥1GB):    48GB × attempt

A large cell now starts at 48GB and reaches 144GB by attempt 3, well
above the ~40GB needed for high-coverage DLP+ cells that align against
3 reference genomes (GRCh37 + mm10 + salmon) simultaneously.