### PR TITLE
fix: SPLITBAM_TASK is always allocated 1 cpu regardless of num_threads

### DIFF
--- a/modules/local/split_bam/main.nf
+++ b/modules/local/split_bam/main.nf
@@ -1,6 +1,6 @@
 process SPLITBAM_TASK {
     time '48h'
-    cpus 1
+    cpus { num_threads as int }
     memory '12 GB'
     label 'process_high'
 


### PR DESCRIPTION
`SPLITBAM_TASK` hands its `num_threads` input straight to `samtools split --threads`, but declares `cpus 1`. The executor therefore allocates a single core no matter what the caller asks for, and the split runs effectively single-threaded. Nothing errors, so this is invisible unless you look at the scheduler's `ReqCPUS`.

Both call paths are affected:

- `MONDRIAN_COUNTHAPS` — `SPLITBAM(tumor_bam, numcores)`, `subworkflows/local/counthaps.nf`
- `MONDRIAN_CONTAMINATION` — `SPLITBAM(bam_files, num_cores)`, `subworkflows/local/contamination.nf`

### The change

```groovy
-    cpus 1
+    cpus { num_threads as int }
```

This follows the dynamic-directive convention introduced for `ALIGN` in #18. Verified on Nextflow 23.04.4 with a minimal harness — the closure resolves per task and `task.cpus` tracks the input value.

I deliberately did not add `* task.attempt` escalation as `ALIGN` has. `conf/base.config` retries only on OOM/kill exit statuses (`143,137,104,134,139`), which extra threads would not address. Happy to add it for consistency if you would rather the two modules match exactly.

### Effect

Measured on a 39 GiB single-cell BAM, same input, both runs concurrent on the same cluster:

| | elapsed |
|---|---|
| `SPLITBAM_TASK`, 1 cpu | 2h14m34s |
| `SPLITBAM_TASK`, 10 cpus | 0h47m05s (2.85x) |

A 126 GiB BAM split in 1h32m at 10 threads, against 5h25m for a comparable 110 GiB BAM at 1 thread. Memory is unaffected — 7.0 GB peak against the 12 GB request — so this costs cores, not RAM.

`samtools split --threads` governs compression threads, so the speedup is solid but sub-linear; 10 threads is not 10x.

### Unrelated observation, not addressed here

`conf/modules.config:66` declares:

```groovy
withName: 'MONDRIAN:MONDRIAN_COUNTHAPS_PIPELINE:MONDRIAN_COUNTHAPS:SPLITBAM' {
    container = "quay.io/biocontainers/samtools:1.21--h50ea8bc_0"
}
```

That selector names the *workflow*; the task's fully qualified name is `...:MONDRIAN_COUNTHAPS:SPLITBAM:SPLITBAM_TASK`, so it never matches. Nextflow says as much on every counthaps run:

```
WARN nextflow.Session - There's no process matching config selector:
  MONDRIAN:MONDRIAN_COUNTHAPS_PIPELINE:MONDRIAN_COUNTHAPS:SPLITBAM
```

The practical effect is that the samtools 1.21 pin has never applied — `SPLITBAM_TASK` picks up 1.22.1 from the `withName: 'SPLITBAM_TASK'` entry at line 58 instead. I left it alone because the right fix depends on whether the 1.21 pin was intended: dropping the block matches what has actually been running, whereas repairing the selector would downgrade the container. Glad to follow up either way, or to open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7bdngMo25BQQrKrNZtA8A
